### PR TITLE
Add Classlist::Reset to replace all entries

### DIFF
--- a/lib/classlist/reset.rb
+++ b/lib/classlist/reset.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "classlist"
+
+# Classlist::Reset is a classlist that removes all tokens from the original
+# classlist when merged.
+class Classlist::Reset < Classlist
+  def merge(original)
+    original.entries.replace(entries)
+  end
+end

--- a/test/classlist/test_reset.rb
+++ b/test/classlist/test_reset.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+require "classlist/reset"
+
+class TestClasslistReset < Minitest::Test
+  def test_inherits_from_classlist
+    classlist = Classlist::Reset.new("foo")
+    assert_kind_of(Classlist, classlist)
+  end
+end
+
+class TestAddingToClasslist < Minitest::Test
+  def test_replaces_existing_tokens_in_the_classlist
+    classlist = Classlist.new("foo bar baz")
+    reset = Classlist::Reset.new("baz foo")
+
+    result = classlist + reset
+
+    assert_equal(Classlist.new("baz foo"), result)
+  end
+
+  def test_replaces_an_empty_classlist
+    classlist = Classlist.new("")
+    reset = Classlist::Reset.new("something")
+
+    result = classlist + reset
+
+    assert_equal(Classlist.new("something"), result)
+  end
+end


### PR DESCRIPTION
I considered using Classlist::Replace as the name, however given that we have a `Classlist#replace` method that replaces a single token with another, I worried there'd be confusion when Classlist::Replace did something entirely different.