### PR TITLE
Migrate away from standardrb-action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,5 +34,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler: 2.4.22 # For Ruby 2.7 compatibility
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -3,11 +3,12 @@ name: StandardRB
 on: [push]
 
 jobs:
-  build:
+  standardrb:
+    name: StandardRB
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: StandardRB Linter
-      uses: andrewmcodes/standardrb-action@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec standardrb --format github --parallel

--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -11,4 +11,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          ruby-version: 3.3
       - run: bundle exec standardrb --format github --parallel


### PR DESCRIPTION
Because Andrew told us to:

> This action is unnecessary and will slow down your CI suite. As such, it is not actively maintained.
> https://github.com/andrewmcodes/standardrb-action?tab=readme-ov-file