### PR TITLE
Fix additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code of Conduct.
 - Add support for Ruby 3.2 and 3.3 (no changes).
 
+### Fixed
+
+- Adding a raw `Classlist` to a set of `Classlist::Operation`s would merge the `Classlist` into the last operation, instead of treating the `Classlist` as an implicit `Classlist::Add` operation (which it should be).
+
 ## [1.1.0] - 2022-11-07
 
 ### Added

--- a/lib/classlist.rb
+++ b/lib/classlist.rb
@@ -16,6 +16,11 @@ class Classlist
 
   # Returns the Classlist resulting from adding other to this classlist.
   def +(other)
+    # When adding a basic Classlist to an existing list, assume an Add operation
+    if other.is_a?(Classlist) && !other.is_a?(Classlist::Operation)
+      other = Classlist::Add.new(other.entries.dup)
+    end
+
     case other
     when Classlist::Operation
       add_operation(other)

--- a/lib/classlist.rb
+++ b/lib/classlist.rb
@@ -10,6 +10,7 @@ class Classlist
   class Error < StandardError; end
 
   extend Forwardable
+
   def_delegators :@entries, :each
 
   attr_reader :entries, :operations

--- a/test/classlist/test_operation.rb
+++ b/test/classlist/test_operation.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 require "classlist/add"
 require "classlist/remove"
+require "classlist/reset"
 
 class TestClasslistOperation < Minitest::Test
   def test_add

--- a/test/classlist/test_operation.rb
+++ b/test/classlist/test_operation.rb
@@ -93,6 +93,22 @@ class TestClasslistOperation < Minitest::Test
     assert_equal(["this"], result.to_a)
   end
 
+  def test_adding_after_removing
+    base = Classlist.new("foo")
+    removal = Classlist::Remove.new("foo")
+    addition = Classlist::Add.new("addition")
+    result = base + removal + addition
+    assert_equal(["addition"], result.to_a)
+  end
+
+  def test_adding_a_classlist_instance_assumes_add
+    base = Classlist.new("foo")
+    removal = Classlist::Remove.new("foo")
+    addition = Classlist.new("addition")
+    result = base + removal + addition
+    assert_equal(["addition"], result.to_a)
+  end
+
   def test_all_the_operations
     result = Classlist.new("start") +
       Classlist::Reset.new("with") +


### PR DESCRIPTION
Ie doing

    Classlist.new("a b c") + Classlist.new("d e")

is the same as

    Classlist.new("a b c") + Classlist::Add.new("d e")

and most notably doing

    Classlist.new("a") + Classlist::Remove.new("a") + Classlist.new("b")

is the same as

    Classlist.new("a") + Classlist::Remove.new("a") + Classlist::Add.new("b")

which it wasn't before.

Adding a "base" Classlist in that manner would merge it into the Remove
operation, effectively turning the statement into

    Classlist.new("a") + Classlist::Remove.new("a b")

which is not the intended behavior