### PR TITLE
Run just the tests as part of the "Run tests" step

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,4 +33,4 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
         bundler: 2.4.22 # For Ruby 2.7 compatibility
     - name: Run tests
-      run: bundle exec rake
+      run: bundle exec rake test


### PR DESCRIPTION
Running `rake` without specifying a task may run additional tasks, and it actually runs the linter as well. We have a separate step for linting, so we should only run the tests here.